### PR TITLE
tagged-git: use fetch --tags to overwrite local tags.

### DIFF
--- a/upstream-git.lisp
+++ b/upstream-git.lisp
@@ -24,7 +24,7 @@
 
 (defmethod vcs-update ((source tagged-git-source) checkout-directory)
   (with-posix-cwd checkout-directory
-    (run "git" "fetch")
+    (run "git" "fetch" "--tags")
     (run "git" "checkout" (tag-data source))))
 
 (defmethod vcs-update :after ((source git-source) checkout-directory)


### PR DESCRIPTION
without --tags git will not overwrite the local tags if someone has moved them in the remote with a push --force.

this is a step towards making tagged-git work seamlessly in a setup where project authors can move a tag called 'quicklisp' to the revision they propose to go into quicklisp.

unfortunately i couldn't test any of this.