### PR TITLE
record some metadata for each package

### DIFF
--- a/dist-cache.lisp
+++ b/dist-cache.lisp
@@ -261,6 +261,10 @@ if needed."
   (ensure-system-file-index)
   (ignore-errors (system-file-systems system-name)))
 
+(defun system-nonblacklisted-systems (source system-name)
+  (remove-if (lambda (system-name) (blacklistedp source system-name))
+             (system-defined-systems system-name)))
+
 (defun find-fake-winning-systems (source)
   (let ((fake-wins (relative-to source "wins.txt"))
         (*read-eval* nil))
@@ -365,6 +369,14 @@ their name does not match the system file name."
       (dolist (system (ignore-errors (system-defined-systems system-file-name)))
         (unless (blacklistedp source system)
           (funcall fun system-file-name system))))))
+
+(defun collect-source-systems (source)
+  (ensure-system-file-index)
+  (setf source (source-designator source))
+  (with-system-index
+      (loop
+         for system-file-name in (system-names source)
+         appending (system-nonblacklisted-systems source system-file-name))))
 
 (defun acceptable-system-name (name)
   (declare (ignore name))

--- a/misc.lisp
+++ b/misc.lisp
@@ -526,3 +526,59 @@
          (when new-source
            (setf (first-line (source-file source))
                  new-source)))))))
+
+;;; write metadata.sexp files
+
+(defun write-metadata-sexps ()
+  (ensure-system-file-index)
+  (with-skipping
+    (map-sources
+     (lambda (source)
+       (format t "mapping over the system files in source ~A~%" source)
+       (dolist (system-file-name (system-names source))
+         (let ((metadata-file (make-pathname :defaults (source-file source)
+                                             :name (format nil "~A.metadata" system-file-name)
+                                             :type "sexp")))
+           (format t "writing system metadata to ~A~%" metadata-file)
+           (system-file-magic (car (last (system-nonblacklisted-systems source system-file-name)))
+                              (project-name source)
+                              metadata-file)))
+       (flet ((trim-prefix (file)
+                (subseq file (1+ (position #\/ file)))))
+         (let ((metadata-file (make-pathname :defaults (source-file source)
+                                             :name "metadata"
+                                             :type "sexp")))
+           (with-open-file (stream metadata-file :direction :output :if-exists :supersede)
+             (let* ((tarball (ensure-cached-release-tarball source))
+                    (project-name (project-name source))
+                    (url (format nil "http://~A/archive/~A/~A/~A"
+                                 *s3-bucket*
+                                 project-name
+                                 (dist-string (file-write-date tarball))
+                                 (file-namestring tarball)))
+                    (system-files (system-names source))
+                    (systems (loop
+                                for system-file-name in system-files
+                                collecting (cons system-file-name
+                                                 (read (open (make-pathname :defaults metadata-file
+                                                                            :name (format nil "~A.metadata" system-file-name)
+                                                                            :type "sexp"))))))
+                    (primary-system-file-metadata (cdr (assoc project-name systems :test #'equal)))
+                    (primary-system-metadata (cdr (assoc project-name primary-system-file-metadata :test #'equal))))
+                 (format t "writing project metadata to ~A~%" metadata-file)
+                 (pprint (list :project project-name
+                               :description (getf primary-system-metadata :description)
+                               :long-description (getf primary-system-metadata :long-description)
+                               :license (getf primary-system-metadata :license)
+                               :author (getf primary-system-metadata :author)
+                               :homepage (getf primary-system-metadata :homepage)
+                               :bug-tracker (getf primary-system-metadata :bug-tracker)
+                               :depends-on (getf primary-system-metadata :depends-on)
+                               :release-url url
+                               :size (file-size tarball)
+                               :file-md5 (file-md5 tarball)
+                               :file-sha256 (file-sha256 tarball)
+                               :file-content-sha1 (first (last (pathname-directory tarball)))
+                               :system-files system-files
+                               :systems systems)
+                         stream)))))))))

--- a/utils.lisp
+++ b/utils.lisp
@@ -244,6 +244,10 @@ template pathname."
   (ironclad:byte-array-to-hex-string
    (ironclad:digest-file :md5 file)))
 
+(defun file-sha256 (file)
+  (ironclad:byte-array-to-hex-string
+   (ironclad:digest-file :sha256 file)))
+
 (defun dist-string (&optional (timestamp (get-universal-time)))
   (multiple-value-bind (second minute hour day month year)
       (decode-universal-time timestamp 0)


### PR DESCRIPTION
I think it would be nice to be able to query package metadata without actually having to download the packages. This patch generates a metadata.sexp file for each package. For actually searching for packages it'd be nice to have a single file with all of the metadata, but I haven't gotten that far. Nor have I modified quicklisp-client to let users query this data. My goal for the moment is to allow Guix to install packages directly from the Quicklisp repository. I welcome your comments, suggestions, improvements, etc.

The code is probably not very beautiful, and system-file-magic is now doing two jobs at once. Better argument passing/parsing could help clean that up, or it could be changed to just output the metadata (and to stdout for easier access) so that the caller could do with it what they want. The existing callers could grab the list of systems, while write-metadata-sexps could save it to the file.