### PR TITLE
Archive submodules

### DIFF
--- a/upstream-git.lisp
+++ b/upstream-git.lisp
@@ -85,9 +85,8 @@
           (with-binary-run-output temptar
             (run "git" "archive" :format "tar" :prefix prefix
                  (target-ref source)))
-          (without-run-output
-            (run "git" "submodule" "foreach" :recursive :quiet
-                 (submodule-git-archive-command prefix tempsub)))
+          (run "git" "submodule" "foreach" :recursive :quiet
+               (submodule-git-archive-command prefix tempsub))
           (dolist (archive (directory (merge-pathnames "**/*.tar" tempsub)))
             (run "tar" "Af" temptar archive))
           (run "gzip" "-vn9" temptar)


### PR DESCRIPTION
Related to https://github.com/quicklisp/quicklisp-projects/issues/685 and https://github.com/quicklisp/quicklisp-projects/issues/728.

When making a release tarball, add a temporary `submodules/` directory
and create archives for all submodules, using `git submodules foreach`
calling `git archive HEAD`. Concatenate the resulting archives 
into the main one.

I tested by running:

```
(make-release-tarball 
 (make-instance 'git-source
                :project-name "cl-ledger"
                :location "https://github.com/ledger/cl-ledger")
 #P"/tmp/test.tgz")
```

I also let ensure-what-wins-you-can run for a while to see if projects 
without submodules were still building.

NB. It could be the case that a submodule is another system already registered in ASDF,
possibly from another version (for example, the submodule points to a previous release).
I am not sure if this is a problem and what should be in done in that case.