### PR TITLE
Add support for latest releases from Gitea/Forgejo

### DIFF
--- a/quicklisp-controller.asd
+++ b/quicklisp-controller.asd
@@ -39,6 +39,7 @@
                (:file "upstream-git")
                (:file "upstream-github")
                (:file "upstream-gitlab")
+               (:file "upstream-gitea")
                (:file "upstream-mercurial")
                (:file "upstream-svn")
                (:file "upstream-bzr")

--- a/upstream-gitea.lisp
+++ b/upstream-gitea.lisp
@@ -1,0 +1,38 @@
+;;;; upstream-gitea.lisp
+;;;;
+;;;; Fetch some basic info about a source from a gitea/forgejo instance
+;;;;
+
+(in-package #:quicklisp-controller)
+
+(defun gitea-project-data (url)
+  (ppcre:register-groups-bind (host owner repo)
+      ("//([^/]+?)/([^/]+?)/([^/]+?)(\\.git)?$" url)
+    (values host owner repo)))
+
+(defun gitea-latest-release-uri (repo-url)
+  "Given a URL from a Gitea repo, give a URI to the latest release"
+  (multiple-value-bind (host owner repo) (gitea-project-data repo-url)
+    (format nil "https://~A/api/v1/repos/~A/~A/releases/latest"
+		      host owner repo)))
+
+
+(defun gitea-project-release-json (url)
+  (let* ((uri (gitea-latest-release-uri url))
+	 (request (make-instance 'githappy::request
+				 :uri uri))
+	 (response (githappy::submit request))
+	 (json (yason:parse (githappy::utf8-string (githappy::body response)))))
+    json))
+
+(defun gitea-latest-release-info (url)
+  (let ((json (gitea-project-release-json url)))
+    (when json
+      (list :tag (githappy:jref json "tag_name")
+	    :url (githappy:jref json "tarball_url")))))
+
+(defclass latest-gitea-release-source (latest-github-release-source)
+  ())
+
+(defmethod github-info-plist ((source latest-gitea-release-source))
+  (gitea-latest-release-info (location source)))


### PR DESCRIPTION
This pull-request adds support for automatic inclusion of the latest release of projects hosted on Gitea/Forgejo instances such as [Codeberg.org](https://codeberg.org/), see issue #23. It allows the following syntax in `source.txt`:
```
gitea-latest-release <git repository on a gitea instance>
```
An example would be:
```
latest-gitea-release https://codeberg.org/osh-autodoc/cl-scribble-subset-parser.git
```
The addition is based on the code for Gitlab and it was tested on [Quicklisp Projects](https://github.com/quicklisp/quicklisp-projects).

Thanks in advance for considering this pull request.